### PR TITLE
Upgrade GitHub Action versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
     - name: test
       run: |
         npm install


### PR DESCRIPTION
Older versions won't work due to GitHub deprecating the use of older Node.js versions (which many actions use).